### PR TITLE
Update Expertise layout per spec

### DIFF
--- a/src/sections/Expertise.tsx
+++ b/src/sections/Expertise.tsx
@@ -15,8 +15,8 @@ const DescriptonBlock: React.FC<DescriptonBlockProps> = ({
   const block = classNames(defaultContainer(), classname);
   return (
     <div className={block}>
-      <h2 className="uppercase text-2xl">{title}</h2>
-      <p className="text-xl">{children}</p>
+      <h2 className="uppercase text-[4cqw]">{title}</h2>
+      <p className="text-[3cqw]">{children}</p>
     </div>
   );
 };
@@ -24,25 +24,40 @@ const DescriptonBlock: React.FC<DescriptonBlockProps> = ({
 const Expertise: React.FC = () => {
   return (
     <section id="experience" className="p-8 flex justify-end">
-      <div className="flex flex-wrap max-w-xl">
-        <DescriptonBlock title="Character Info" classname="grow">
-          <>
-            name: Vladislav S.
-            <br />
-            status: Open to work
-            <br />
-            experience: 4+ years
-            <br />
-            titles: Software Engineer, Frontend Developer, Excellent Problem
-            Solver
-          </>
-        </DescriptonBlock>
-        <DescriptonBlock title="Portrait" classname="w-[200px]" />
-        <div className="w-full" />
-        <DescriptonBlock title="Frontend" classname="grow" />
-        <div className="w-full" />
-        <DescriptonBlock title="Software Engineer" classname="grow" />
-        <DescriptonBlock title="Miscellaneous" classname="grow" />
+      <div
+        id="cardWrapper"
+        className="flex flex-col flex-wrap [container-type:inline-size]"
+        style={{ width: "min(max(40vw,36rem),100vw)" }}
+      >
+        <div className="flex flex-wrap items-stretch w-full">
+          <DescriptonBlock title="Character Info" classname="grow">
+            <>
+              name: Vladislav S.
+              <br />
+              status: Open to work
+              <br />
+              experience: 4+ years
+              <br />
+              titles: Software Engineer, Frontend Developer, Excellent Problem
+              Solver
+            </>
+          </DescriptonBlock>
+          <DescriptonBlock
+            title="Portrait"
+            classname="aspect-square self-stretch min-w-[200px] min-h-[200px]"
+          />
+        </div>
+        <DescriptonBlock title="Frontend" classname="w-full" />
+        <div className="flex flex-wrap w-full">
+          <DescriptonBlock
+            title="Software Engineer"
+            classname="flex-1 min-w-[250px]"
+          />
+          <DescriptonBlock
+            title="Miscellaneous"
+            classname="flex-1 min-w-[250px]"
+          />
+        </div>
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
- update font sizes within Expertise description blocks to scale with `cardWrapper`
- add `cardWrapper` element with dynamic width and container query support
- restructure Expertise layout to group Character Info with Portrait and add responsive columns

## Testing
- `npx eslint src/sections/Expertise.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68812a252c48832faa0d4235976d17b8