### PR TITLE
Refactor expertise and work data

### DIFF
--- a/src/data/expertise.tsx
+++ b/src/data/expertise.tsx
@@ -1,0 +1,61 @@
+import { unorderedList } from "../stylizers";
+import React from "react";
+
+export const expertiseContent: Record<string, React.ReactNode> = {
+  "Character Info": (
+    <p>
+      name: Vladislav S.
+      <br />
+      status: Open to work
+      <br />
+      experience: 4+ years
+      <br />
+      titles: Software Engineer, Frontend Developer, Excellent Problem Solver
+    </p>
+  ),
+  Frontend: (
+    <>
+      Basics:
+      <ul className={unorderedList}>
+        <li>HTML, CSS, JS, Figma</li>
+      </ul>
+      Frameworks:
+      <ul className={unorderedList}>
+        <li>Vast experience with React + Redux</li>
+        <li>Knowledge of Vue, Angular, Next</li>
+      </ul>
+      Testing:
+      <ul className={unorderedList}>
+        <li>e2e: cypress, storybook</li>
+        <li>unit: jest, react testing library</li>
+      </ul>
+      Others:
+      <ul className={unorderedList}>
+        <li>GraphQL, Tailwind, Docker, Webpack, Vite</li>
+        <li>And so on...</li>
+      </ul>
+    </>
+  ),
+  "Software Engineer": (
+    <>
+      Experience in functional and OOP:
+      <ul className={unorderedList}>
+        <li>JavaScript</li>
+        <li>TypeScript</li>
+        <li>Python</li>
+        <li>C#</li>
+        <li>Java</li>
+      </ul>
+    </>
+  ),
+  Miscellaneous: (
+    <>
+      Beside my main focus I'm also have knowledge in:
+      <ul className={unorderedList}>
+        <li>backend development</li>
+        <li>machine learning</li>
+      </ul>
+    </>
+  ),
+};
+

--- a/src/data/projects.tsx
+++ b/src/data/projects.tsx
@@ -1,0 +1,29 @@
+import FoldImage from "../assets/Fold.svg";
+import type { ProjectCardProps } from "../types";
+
+const placeholder = (
+  <p>
+    This is a placeholder description of the project. Clicking the image or the
+    button opens this modal. This is a placeholder description of the project.
+    Clicking the image or the button opens this modal. This is a placeholder
+    description of the project. Clicking the image or the button opens this
+    modal.
+  </p>
+);
+
+export const projects: ProjectCardProps[] = [
+  {
+    title: "Example",
+    tags: ["react", "vite"],
+    image: FoldImage,
+    stack: ["react", "vite", "tailwind"],
+    content: placeholder,
+  },
+  {
+    title: "Example",
+    tags: ["react", "vite"],
+    image: FoldImage,
+    stack: ["react", "vite", "tailwind"],
+    content: <p>Another project description.</p>,
+  },
+];

--- a/src/sections/Expertise.tsx
+++ b/src/sections/Expertise.tsx
@@ -1,11 +1,7 @@
 import classNames from "classnames";
-import { defaultContainer, unorderedList } from "../stylizers";
-
-interface DescriptonBlockProps {
-  title?: string;
-  classname?: string;
-  children?: React.ReactNode;
-}
+import { defaultContainer } from "../stylizers";
+import { expertiseContent } from "../data/expertise";
+import type { DescriptonBlockProps } from "../types";
 
 const DescriptonBlock: React.FC<DescriptonBlockProps> = ({
   title,
@@ -25,6 +21,45 @@ const DescriptonBlock: React.FC<DescriptonBlockProps> = ({
   );
 };
 
+const renderBlocks = (blocks: DescriptonBlockProps[]) =>
+  blocks.map((block, idx) => (
+    <DescriptonBlock key={idx} {...block} />
+  ));
+
+const firstRow: DescriptonBlockProps[] = [
+  {
+    title: "Portrait",
+    classname:
+      "aspect-square self-stretch min-h-[200px] grow @md:grow-0 @max-md:border-b-0 @md:border-r-0",
+  },
+  {
+    title: "Character Info",
+    classname: "grow",
+    children: expertiseContent["Character Info"],
+  },
+];
+
+const secondRow: DescriptonBlockProps[] = [
+  {
+    title: "Frontend",
+    classname: "w-full border-t-0 border-b-0",
+    children: expertiseContent.Frontend,
+  },
+];
+
+const thirdRow: DescriptonBlockProps[] = [
+  {
+    title: "Software Engineer",
+    classname: "flex-1 basis-[250px] @max-md:border-b-0 @md:border-r-0",
+    children: expertiseContent["Software Engineer"],
+  },
+  {
+    title: "Miscellaneous",
+    classname: "flex-1 basis-[250px]",
+    children: expertiseContent.Miscellaneous,
+  },
+];
+
 const Expertise: React.FC = () => {
   return (
     <section id="experience" className="p-8 flex justify-end">
@@ -34,75 +69,11 @@ const Expertise: React.FC = () => {
         style={{ width: "min(max(40vw,36rem),100vw)" }}
       >
         <div className="flex flex-wrap @md:flex-nowrap items-stretch w-full">
-          <DescriptonBlock
-            title="Portrait"
-            classname="aspect-square self-stretch min-h-[200px] grow @md:grow-0 @max-md:border-b-0 @md:border-r-0"
-          />
-          <DescriptonBlock title="Character Info" classname="grow">
-            <p>
-              name: Vladislav S.
-              <br />
-              status: Open to work
-              <br />
-              experience: 4+ years
-              <br />
-              titles: Software Engineer, Frontend Developer, Excellent Problem
-              Solver
-            </p>
-          </DescriptonBlock>
+          {renderBlocks(firstRow)}
         </div>
-        <DescriptonBlock
-          title="Frontend"
-          classname="w-full border-t-0 border-b-0"
-        >
-          <>
-            Basics:
-            <ul className={unorderedList}>
-              <li>HTML, CSS, JS, Figma</li>
-            </ul>
-            Frameworks:
-            <ul className={unorderedList}>
-              <li>Vast experience with React + Redux</li>
-              <li>Knowledge of Vue, Angular, Next</li>
-            </ul>
-            Testing:
-            <ul className={unorderedList}>
-              <li>e2e: cypress, storybook</li>
-              <li>unit: jest, react testing library</li>
-            </ul>
-            Others:
-            <ul className={unorderedList}>
-              <li>GraphQL, Tailwind, Docker, Webpack, Vite</li>
-              <li>And so on...</li>
-            </ul>
-          </>
-        </DescriptonBlock>
+        {renderBlocks(secondRow)}
         <div className="flex flex-wrap @md:flex-nowrap w-full">
-          <DescriptonBlock
-            title="Software Engineer"
-            classname="flex-1 basis-[250px] @max-md:border-b-0 @md:border-r-0"
-          >
-            <>
-              Experience in functional and OOP:
-              <ul className={unorderedList}>
-                <li>JavaScript</li>
-                <li>TypeScript</li>
-                <li>Python</li>
-                <li>C#</li>
-                <li>Java</li>
-              </ul>
-            </>
-          </DescriptonBlock>
-          <DescriptonBlock
-            title="Miscellaneous"
-            classname="flex-1 basis-[250px]"
-          >
-            Beside my main focus I'm also have knowledge in:
-            <ul className={unorderedList}>
-              <li>backend development</li>
-              <li>machine learning</li>
-            </ul>
-          </DescriptonBlock>
+          {renderBlocks(thirdRow)}
         </div>
       </div>
     </section>

--- a/src/sections/Expertise.tsx
+++ b/src/sections/Expertise.tsx
@@ -2,6 +2,7 @@ import classNames from "classnames";
 import { defaultContainer } from "../stylizers";
 import { expertiseContent } from "../data/expertise";
 import type { DescriptonBlockProps } from "../types";
+import { useCallback } from "react";
 
 const DescriptonBlock: React.FC<DescriptonBlockProps> = ({
   title,
@@ -20,11 +21,6 @@ const DescriptonBlock: React.FC<DescriptonBlockProps> = ({
     </div>
   );
 };
-
-const renderBlocks = (blocks: DescriptonBlockProps[]) =>
-  blocks.map((block, idx) => (
-    <DescriptonBlock key={idx} {...block} />
-  ));
 
 const firstRow: DescriptonBlockProps[] = [
   {
@@ -61,8 +57,14 @@ const thirdRow: DescriptonBlockProps[] = [
 ];
 
 const Expertise: React.FC = () => {
+  const renderBlocks = useCallback(
+    (blocks: DescriptonBlockProps[]) =>
+      blocks.map((block, idx) => <DescriptonBlock key={idx} {...block} />),
+    []
+  );
+
   return (
-    <section id="experience" className="p-8 flex justify-end">
+    <section id="expertise" className="p-8 flex justify-end">
       <div
         id="cardWrapper"
         className="flex flex-col flex-wrap @container"

--- a/src/sections/MyWork.tsx
+++ b/src/sections/MyWork.tsx
@@ -1,16 +1,9 @@
 import React from "react";
 import classNames from "classnames";
 import { defaultContainer } from "../stylizers";
-import FoldImage from "../assets/Fold.svg";
 import Modal from "../components/Modal";
-
-export interface ProjectCardProps {
-  title: string;
-  tags: string[];
-  image: string;
-  stack: string[];
-  content: React.ReactNode;
-}
+import type { ProjectCardProps } from "../types";
+import { projects } from "../data/projects";
 
 export const ProjectCard: React.FC<ProjectCardProps> = ({
   title,
@@ -69,172 +62,9 @@ const MyWork: React.FC = () => {
       id="work"
       className="p-8 flex flex-wrap gap-12 max-md:justify-center min-h-[100vh]"
     >
-      <ProjectCard
-        title="Example"
-        tags={["react", "vite"]}
-        image={FoldImage}
-        stack={["react", "vite", "tailwind"]}
-        content={
-          <p>
-            This is a placeholder description of the project. Clicking the image
-            or the button opens this modal. This is a placeholder description of
-            the project. Clicking the image or the button opens this modal. This
-            is a placeholder description of the project. Clicking the image or
-            the button opens this modal. This is a placeholder description of
-            the project. Clicking the image or the button opens this modal.This
-            is a placeholder description of the project. Clicking the image or
-            the button opens this modal.This is a placeholder description of the
-            project. Clicking the image or the button opens this modal.This is a
-            placeholder description of the project. Clicking the image or the
-            button opens this modal.This is a placeholder description of the
-            project. Clicking the image or the button opens this modal.This is a
-            placeholder description of the project. Clicking the image or the
-            button opens this modal.This is a placeholder description of the
-            project. Clicking the image or the button opens this modal.This is a
-            placeholder description of the project. Clicking the image or the
-            button opens this modal.This is a placeholder description of the
-            project. Clicking the image or the button opens this modal.This is a
-            placeholder description of the project. Clicking the image or the
-            button opens this modal.This is a placeholder description of the
-            project. Clicking the image or the button opens this modal.This is a
-            placeholder description of the project. Clicking the image or the
-            button opens this modal.This is a placeholder description of the
-            project. Clicking the image or the button opens this modal.This is a
-            placeholder description of the project. Clicking the image or the
-            button opens this modal.This is a placeholder description of the
-            project. Clicking the image or the button opens this modal.This is a
-            placeholder description of the project. Clicking the image or the
-            button opens this modal.This is a placeholder description of the
-            project. Clicking the image or the button opens this modal.This is a
-            placeholder description of the project. Clicking the image or the
-            button opens this modal.This is a placeholder description of the
-            project. Clicking the image or the button opens this modal.This is a
-            placeholder description of the project. Clicking the image or the
-            button opens this modal.This is a placeholder description of the
-            project. Clicking the image or the button opens this modal.This is a
-            placeholder description of the project. Clicking the image or the
-            button opens this modal.This is a placeholder description of the
-            project. Clicking the image or the button opens this modal.This is a
-            placeholder description of the project. Clicking the image or the
-            button opens this modal.This is a placeholder description of the
-            project. Clicking the image or the button opens this modal.This is a
-            placeholder description of the project. Clicking the image or the
-            button opens this modal.This is a placeholder description of the
-            project. Clicking the image or the button opens this modal.This is a
-            placeholder description of the project. Clicking the image or the
-            button opens this modal.This is a placeholder description of the
-            project. Clicking the image or the button opens this modal.This is a
-            placeholder description of the project. Clicking the image or the
-            button opens this modal.This is a placeholder description of the
-            project. Clicking the image or the button opens this modal.This is a
-            placeholder description of the project. Clicking the image or the
-            button opens this modal.This is a placeholder description of the
-            project. Clicking the image or the button opens this modal.This is a
-            placeholder description of the project. Clicking the image or the
-            button opens this modal.This is a placeholder description of the
-            project. Clicking the image or the button opens this modal.This is a
-            placeholder description of the project. Clicking the image or the
-            button opens this modal.This is a placeholder description of the
-            project. Clicking the image or the button opens this modal.This is a
-            placeholder description of the project. Clicking the image or the
-            button opens this modal.This is a placeholder description of the
-            project. Clicking the image or the button opens this modal.This is a
-            placeholder description of the project. Clicking the image or the
-            button opens this modal.This is a placeholder description of the
-            project. Clicking the image or the button opens this modal.This is a
-            placeholder description of the project. Clicking the image or the
-            button opens this modal.This is a placeholder description of the
-            project. Clicking the image or the button opens this modal.This is a
-            placeholder description of the project. Clicking the image or the
-            button opens this modal.This is a placeholder description of the
-            project. Clicking the image or the button opens this modal.This is a
-            placeholder description of the project. Clicking the image or the
-            button opens this modal.This is a placeholder description of the
-            project. Clicking the image or the button opens this modal.This is a
-            placeholder description of the project. Clicking the image or the
-            button opens this modal.This is a placeholder description of the
-            project. Clicking the image or the button opens this modal.This is a
-            placeholder description of the project. Clicking the image or the
-            button opens this modal.This is a placeholder description of the
-            project. Clicking the image or the button opens this modal.This is a
-            placeholder description of the project. Clicking the image or the
-            button opens this modal.This is a placeholder description of the
-            project. Clicking the image or the button opens this modal.This is a
-            placeholder description of the project. Clicking the image or the
-            button opens this modal.This is a placeholder description of the
-            project. Clicking the image or the button opens this modal.This is a
-            placeholder description of the project. Clicking the image or the
-            button opens this modal.This is a placeholder description of the
-            project. Clicking the image or the button opens this modal.This is a
-            placeholder description of the project. Clicking the image or the
-            button opens this modal.This is a placeholder description of the
-            project. Clicking the image or the button opens this modal.This is a
-            placeholder description of the project. Clicking the image or the
-            button opens this modal.This is a placeholder description of the
-            project. Clicking the image or the button opens this modal.This is a
-            placeholder description of the project. Clicking the image or the
-            button opens this modal.This is a placeholder description of the
-            project. Clicking the image or the button opens this modal.This is a
-            placeholder description of the project. Clicking the image or the
-            button opens this modal.This is a placeholder description of the
-            project. Clicking the image or the button opens this modal.This is a
-            placeholder description of the project. Clicking the image or the
-            button opens this modal.This is a placeholder description of the
-            project. Clicking the image or the button opens this modal.This is a
-            placeholder description of the project. Clicking the image or the
-            button opens this modal.This is a placeholder description of the
-            project. Clicking the image or the button opens this modal.This is a
-            placeholder description of the project. Clicking the image or the
-            button opens this modal.This is a placeholder description of the
-            project. Clicking the image or the button opens this modal.This is a
-            placeholder description of the project. Clicking the image or the
-            button opens this modal.This is a placeholder description of the
-            project. Clicking the image or the button opens this modal.This is a
-            placeholder description of the project. Clicking the image or the
-            button opens this modal.This is a placeholder description of the
-            project. Clicking the image or the button opens this modal.This is a
-            placeholder description of the project. Clicking the image or the
-            button opens this modal.This is a placeholder description of the
-            project. Clicking the image or the button opens this modal.This is a
-            placeholder description of the project. Clicking the image or the
-            button opens this modal.This is a placeholder description of the
-            project. Clicking the image or the button opens this modal.This is a
-            placeholder description of the project. Clicking the image or the
-            button opens this modal.This is a placeholder description of the
-            project. Clicking the image or the button opens this modal.This is a
-            placeholder description of the project. Clicking the image or the
-            button opens this modal.This is a placeholder description of the
-            project. Clicking the image or the button opens this modal.This is a
-            placeholder description of the project. Clicking the image or the
-            button opens this modal.This is a placeholder description of the
-            project. Clicking the image or the button opens this modal.This is a
-            placeholder description of the project. Clicking the image or the
-            button opens this modal.This is a placeholder description of the
-            project. Clicking the image or the button opens this modal.This is a
-            placeholder description of the project. Clicking the image or the
-            button opens this modal.This is a placeholder description of the
-            project. Clicking the image or the button opens this modal.This is a
-            placeholder description of the project. Clicking the image or the
-            button opens this modal.This is a placeholder description of the
-            project. Clicking the image or the button opens this modal.This is a
-            placeholder description of the project. Clicking the image or the
-            button opens this modal.This is a placeholder description of the
-            project. Clicking the image or the button opens this modal.This is a
-            placeholder description of the project. Clicking the image or the
-            button opens this modal.This is a placeholder description of the
-            project. Clicking the image or the button opens this modal.This is a
-            placeholder description of the project. Clicking the image or the
-            button opens this modal.
-          </p>
-        }
-      />
-      <ProjectCard
-        title="Example"
-        tags={["react", "vite"]}
-        image={FoldImage}
-        stack={["react", "vite", "tailwind"]}
-        content={<p>Another project description.</p>}
-      />
+      {projects.map((project) => (
+        <ProjectCard key={project.title} {...project} />
+      ))}
     </section>
   );
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,15 @@
+import React from "react";
+
+export interface ProjectCardProps {
+  title: string;
+  tags: string[];
+  image: string;
+  stack: string[];
+  content: React.ReactNode;
+}
+
+export interface DescriptonBlockProps {
+  title?: string;
+  classname?: string;
+  children?: React.ReactNode;
+}


### PR DESCRIPTION
## Summary
- extract project and expertise markup into data files
- share component prop types via `types.ts`
- simplify `MyWork` and `Expertise` components to consume new data
- restructure expertise data by title and keep layout classes in the component

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688945fc2844832faccb5ba66c85f585