### PR TITLE
feat: add accordion job position components

### DIFF
--- a/src/components/Accordion.tsx
+++ b/src/components/Accordion.tsx
@@ -11,18 +11,18 @@ const Accordion: React.FC<AccordionProps> = ({ children }) => {
 
   const headerClasses = classNames(
     defaultContainer(),
-    "p-4 flex justify-between items-center",
+    "p-4 flex justify-between items-center cursor-pointer text-xl",
     open && "border-b-0"
   );
 
   const contentClasses = classNames(
     defaultContainer(false),
-    "border-b-4 border-(--color-primary) mt-4 p-4"
+    "border-b-4 border-(--color-primary) mt-4 p-4 text-xl"
   );
 
   return (
-    <div onClick={() => setOpen(!open)} className="cursor-pointer">
-      <div className={headerClasses}>
+    <div>
+      <div onClick={() => setOpen(!open)} className={headerClasses}>
         <div className="flex-1">{children[0]}</div>
         <span className="ml-4">{open ? "-" : "+"}</span>
       </div>

--- a/src/components/Accordion.tsx
+++ b/src/components/Accordion.tsx
@@ -1,0 +1,34 @@
+import React, { useState } from "react";
+import classNames from "classnames";
+import { defaultContainer } from "../stylizers";
+
+interface AccordionProps {
+  children: [React.ReactNode, React.ReactNode];
+}
+
+const Accordion: React.FC<AccordionProps> = ({ children }) => {
+  const [open, setOpen] = useState(false);
+
+  const headerClasses = classNames(
+    defaultContainer(),
+    "p-4 flex justify-between items-center",
+    open && "border-b-0"
+  );
+
+  const contentClasses = classNames(
+    defaultContainer(false),
+    "border-b-4 border-(--color-primary) mt-4 p-4"
+  );
+
+  return (
+    <div onClick={() => setOpen(!open)} className="cursor-pointer">
+      <div className={headerClasses}>
+        <div className="flex-1">{children[0]}</div>
+        <span className="ml-4">{open ? "-" : "+"}</span>
+      </div>
+      {open && <div className={contentClasses}>{children[1]}</div>}
+    </div>
+  );
+};
+
+export default Accordion;

--- a/src/components/JobPosition.tsx
+++ b/src/components/JobPosition.tsx
@@ -23,12 +23,13 @@ const JobPosition: React.FC<JobPositionProps> = ({
   const header = (
     <div className="flex justify-between w-full">
       <div>
-        {title} | {" "}
+        {title} |{" "}
         <a
           href={site}
           className="underline"
           target="_blank"
           rel="noopener noreferrer"
+          onClick={(e) => e.stopPropagation()}
         >
           {place}
         </a>
@@ -39,9 +40,9 @@ const JobPosition: React.FC<JobPositionProps> = ({
 
   const body = (
     <div>
-      <p className="mb-2">{location}</p>
-      <p className="mb-2">{description}</p>
-      <p>
+      <p className="mb-2 text-secondary">{location}</p>
+      <p className="mb-4">{description}</p>
+      <p className="text-base text-secondary">
         {stack.map((item) => (
           <span key={item} className="mr-2">{`#${item}`}</span>
         ))}

--- a/src/components/JobPosition.tsx
+++ b/src/components/JobPosition.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import Accordion from "./Accordion";
+
+interface JobPositionProps {
+  title: string;
+  place: string;
+  site: string;
+  date: string;
+  location: string;
+  description: string;
+  stack: string[];
+}
+
+const JobPosition: React.FC<JobPositionProps> = ({
+  title,
+  place,
+  site,
+  date,
+  location,
+  description,
+  stack,
+}) => {
+  const header = (
+    <div className="flex justify-between w-full">
+      <div>
+        {title} | {" "}
+        <a
+          href={site}
+          className="underline"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {place}
+        </a>
+      </div>
+      <span>{date}</span>
+    </div>
+  );
+
+  const body = (
+    <div>
+      <p className="mb-2">{location}</p>
+      <p className="mb-2">{description}</p>
+      <p>
+        {stack.map((item) => (
+          <span key={item} className="mr-2">{`#${item}`}</span>
+        ))}
+      </p>
+    </div>
+  );
+
+  return <Accordion>{[header, body]}</Accordion>;
+};
+
+export default JobPosition;

--- a/src/sections/Experience.tsx
+++ b/src/sections/Experience.tsx
@@ -1,12 +1,39 @@
 import classNames from "classnames";
 import { defaultContainer } from "../stylizers";
+import JobPosition from "../components/JobPosition";
 
 const Experience: React.FC = () => {
-  const block = classNames(defaultContainer(), "p-8 flex justify-end");
+  const block = classNames(defaultContainer(), "p-8 flex flex-col gap-4");
 
   return (
     <section id="experience" className={block}>
-      Здесь будет опыт-попыт
+      <JobPosition
+        title="Frontend Developer"
+        place="TechCorp"
+        site="https://techcorp.example"
+        date="2023 - Present"
+        location="Remote"
+        description="Building user interfaces and interactive features."
+        stack={["React", "TypeScript", "TailwindCSS"]}
+      />
+      <JobPosition
+        title="UI Engineer"
+        place="DesignPro"
+        site="https://designpro.example"
+        date="2021 - 2023"
+        location="New York, NY"
+        description="Implemented responsive design and collaborated with designers."
+        stack={["Vue", "SCSS", "Figma"]}
+      />
+      <JobPosition
+        title="Web Developer"
+        place="Freelance"
+        site="https://freelance.example"
+        date="2019 - 2021"
+        location="Moscow, Russia"
+        description="Delivered web solutions for clients across industries."
+        stack={["HTML", "CSS", "JavaScript"]}
+      />
     </section>
   );
 };

--- a/src/sections/Experience.tsx
+++ b/src/sections/Experience.tsx
@@ -1,39 +1,39 @@
-import classNames from "classnames";
-import { defaultContainer } from "../stylizers";
 import JobPosition from "../components/JobPosition";
 
 const Experience: React.FC = () => {
-  const block = classNames(defaultContainer(), "p-8 flex flex-col gap-4");
-
   return (
-    <section id="experience" className={block}>
-      <JobPosition
-        title="Frontend Developer"
-        place="TechCorp"
-        site="https://techcorp.example"
-        date="2023 - Present"
-        location="Remote"
-        description="Building user interfaces and interactive features."
-        stack={["React", "TypeScript", "TailwindCSS"]}
-      />
-      <JobPosition
-        title="UI Engineer"
-        place="DesignPro"
-        site="https://designpro.example"
-        date="2021 - 2023"
-        location="New York, NY"
-        description="Implemented responsive design and collaborated with designers."
-        stack={["Vue", "SCSS", "Figma"]}
-      />
-      <JobPosition
-        title="Web Developer"
-        place="Freelance"
-        site="https://freelance.example"
-        date="2019 - 2021"
-        location="Moscow, Russia"
-        description="Delivered web solutions for clients across industries."
-        stack={["HTML", "CSS", "JavaScript"]}
-      />
+    <section id="experience" className="p-8 min-h-[100vh]">
+      <div className="flex flex-col w-full items-center">
+        <div className="flex flex-col gap-4 max-w-3xl w-full">
+          <JobPosition
+            title="Frontend Developer"
+            place="TechCorp"
+            site="https://techcorp.example"
+            date="2023 - Present"
+            location="Remote"
+            description="Building user interfaces and interactive features."
+            stack={["React", "TypeScript", "TailwindCSS"]}
+          />
+          <JobPosition
+            title="UI Engineer"
+            place="DesignPro"
+            site="https://designpro.example"
+            date="2021 - 2023"
+            location="New York, NY"
+            description="Implemented responsive design and collaborated with designers."
+            stack={["Vue", "SCSS", "Figma"]}
+          />
+          <JobPosition
+            title="Web Developer"
+            place="Freelance"
+            site="https://freelance.example"
+            date="2019 - 2021"
+            location="Moscow, Russia"
+            description="Delivered web solutions for clients across industries."
+            stack={["HTML", "CSS", "JavaScript"]}
+          />
+        </div>
+      </div>
     </section>
   );
 };

--- a/src/sections/Overview.tsx
+++ b/src/sections/Overview.tsx
@@ -11,7 +11,9 @@ export const Overview: React.FC = () => {
         <h1 className="text-9xl text-primary text-center uppercase font-bitcount font-[350]">
           Vladislav
           <br />
-          <span className="text-(--color-primary)">S.</span>
+          <span className="text-(--color-primary) after:content-['.'] after:absolute">
+            S
+          </span>
         </h1>
         <h2 className="text-5xl text-primary text-center lowercase w-full">
           software engineer, frontend developer


### PR DESCRIPTION
## Summary
- add generic Accordion component with plus/minus toggle and stylized containers
- create JobPosition component built on Accordion
- show three example job positions in Experience section

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68906c251128832fbc2b4fda9dfc26d7