### PR TITLE
feat: add glow animation to overview

### DIFF
--- a/src/sections/Overview.tsx
+++ b/src/sections/Overview.tsx
@@ -52,10 +52,13 @@ export const Overview: React.FC = () => {
           </h2>
         </div>
       </div>
-      <div className="grow flex justify-center w-full [container-type:size]">
+      <div className="grow relative flex justify-center w-full [container-type:size]">
         <img
           src={catBonefire}
-          className="pixelated block size-[100cqmin] object-contain"
+          className="pixelated block size-[100cqmin] object-contain relative z-10"
+        />
+        <div
+          className="absolute -z-10 bottom-0 left-1/2 w-[80%] h-[20%] -translate-x-1/2 rounded-full bg-(--color-primary) blur-3xl opacity-70 animate-[glow_3s_ease-in-out_infinite]"
         />
       </div>
       <div className="text-5xl text-primary lowercase">

--- a/src/styles_global.css
+++ b/src/styles_global.css
@@ -65,6 +65,19 @@
   image-rendering: crisp-edges;
 }
 
+/* Animations */
+@keyframes glow {
+  0%,
+  100% {
+    opacity: 0.6;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1.1);
+  }
+}
+
 /* Global styles */
 html {
   scroll-behavior: smooth;


### PR DESCRIPTION
## Summary
- add pulsing glow beneath overview image
- define keyframes for reusable glow animation

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8a98f8c30832fa553202173337713